### PR TITLE
Correct Link to other README.md files and add space to headers Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # The Primo New UI Customization Workflow Development Environment
 
 
-##Package documentation
+## Package documentation
 
 The development package allows you to configure :
 

--- a/VIEW_CODE/README.md
+++ b/VIEW_CODE/README.md
@@ -2,7 +2,7 @@
 # The Primo New UI Customization Workflow Development Environment
 
 
-##Package documentation
+## Package documentation
 
 The development package allows you to configure :
 

--- a/VIEW_CODE/README.md
+++ b/VIEW_CODE/README.md
@@ -28,13 +28,13 @@ The development package allows you to configure :
 - For each configuration type there is a specified folder in the custom package folder (that can be downloaded form your Primo Back Office)
 - In each folder you will find a specific README.md file with recipes/examples.
 
-  [CSS](./VIEW_CODE/css/README.md "css documentation")
+  [CSS](/VIEW_CODE/css/README.md "css documentation")
 
-  [HTML](./VIEW_CODE/html/README.md "html documentation")
+  [HTML](/VIEW_CODE/html/README.md "html documentation")
 
-  [Images](./VIEW_CODE/img/README.md "images documentation")
+  [Images](/VIEW_CODE/img/README.md "images documentation")
 
-  [JavaScript](./VIEW_CODE/js/README.md "javascript documentation")
+  [JavaScript](/VIEW_CODE/js/README.md "javascript documentation")
 
 
 

--- a/VIEW_CODE/css/README.md
+++ b/VIEW_CODE/css/README.md
@@ -1,7 +1,7 @@
 # The Primo New UI Customization Workflow Development Environment
 
 
-##css documentation
+## css documentation
 
 - Primo uses Angular Directives massively in this project
 
@@ -67,7 +67,7 @@ prm-topbar.md-primoExplore-theme input {....}
 
 
 
-##Recipes/Examples:
+## Recipes/Examples:
 
 
 # css Recipe 1 - Color Scheme (Starting from August 2016 Release)

--- a/VIEW_CODE/html/README.md
+++ b/VIEW_CODE/html/README.md
@@ -1,7 +1,7 @@
 # The Primo New UI Customization Workflow Development Environment
 
 
-##html documentation
+## html documentation
 
  - In this folder you will find static html files in their OTB state
  - The files are separated into directories (starting from the November 2016 Release)

--- a/VIEW_CODE/img/README.md
+++ b/VIEW_CODE/img/README.md
@@ -1,7 +1,7 @@
 # The Primo New UI Customization Workflow Development Environment
 
 
-##images documentation
+## images documentation
 
  - Primo allows the customization of the following images;
     1. Library Logo - just place a file named `library-logo.png` in this location

--- a/VIEW_CODE/js/README.md
+++ b/VIEW_CODE/js/README.md
@@ -1,7 +1,7 @@
 # The Primo New UI Customization Workflow Development Environment
 
 
-##JavaScript documentation
+## JavaScript documentation
 
 - When you want to add functionality to your Primo installation you will be using Angular Directives.
 
@@ -41,7 +41,7 @@ Example:
 
 
 
-##Concept
+## Concept
 
 - When You want to add your own JavaScript functionality - you will need to plug-in to placeholder Directives we added to the system.
 - Those directive are added as the last child element for every Primo directive (defined by the `prm-` prefix)
@@ -52,7 +52,7 @@ Example:
 
 
 
-##Recipes/Examples:
+## Recipes/Examples:
 
 # Note:
 


### PR DESCRIPTION
Change the links in this duplicated README.md, otherwise the links are wrong => /VIEW_CODE/VIEW_CODE/... instead of /VIEW_CODE/...

and add space to headers markdown